### PR TITLE
Caches static manifest reads, makes manifest file name configurable.

### DIFF
--- a/lib/hanami-webpack.rb
+++ b/lib/hanami-webpack.rb
@@ -6,6 +6,10 @@ require_relative 'hanami_webpack/view_helper'
 require_relative 'hanami_webpack/dev_server'
 require_relative 'hanami_webpack/security_headers_hijack'
 
+if Hanami::Utils::Blank.blank?(ENV['WEBPACK_MANIFEST_FILE'])
+  ENV['WEBPACK_MANIFEST_FILE'] = 'manifest.json'
+end
+
 if Hanami::Utils::Blank.blank?(ENV['WEBPACK_DEV_SERVER_HOST'])
   ENV['WEBPACK_DEV_SERVER_HOST'] = 'localhost'
 end

--- a/lib/hanami_webpack/config.rb
+++ b/lib/hanami_webpack/config.rb
@@ -2,8 +2,13 @@ require 'hanami/utils/blank'
 
 module HanamiWebpack
   class Config
+
     def self.public_path
       ENV['WEBPACK_PUBLIC_PATH']
+    end
+
+    def self.manifest_file
+      ENV['WEBPACK_MANIFEST_FILE']
     end
 
     def self.dev_server_host

--- a/lib/hanami_webpack/manifest.rb
+++ b/lib/hanami_webpack/manifest.rb
@@ -7,6 +7,7 @@ require_relative 'entry_point_missing_error'
 module HanamiWebpack
   class Manifest
     def self.bundle_uri(bundle_name)
+
       raise HanamiWebpack::WebpackError, manifest['errors'] unless Hanami::Utils::Blank.blank?(manifest['errors'])
 
       path = manifest['assetsByChunkName'][bundle_name]
@@ -25,7 +26,7 @@ module HanamiWebpack
     end
 
     def self.manifest_path
-      Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join('manifest.json')
+      Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(HanamiWebpack::Config.manifest_file)
     end
 
     def self.remote_manifest
@@ -33,19 +34,22 @@ module HanamiWebpack
       port = HanamiWebpack::Config.dev_server_port
       http = Net::HTTP.new(host, port)
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      JSON.parse(http.get(manifest_path).body)
+      response = http.get(manifest_path).body
+      JSON.parse(response)
     end
 
     def self.static_manifest
-      path =
-        Hanami
-          .public_directory
-          .join(*HanamiWebpack::Config.public_path.split('/'))
-          .join('manifest.json')
+      @_manifest ||= begin
+        path =
+          Hanami
+            .public_directory
+            .join(*HanamiWebpack::Config.public_path.split('/'))
+            .join(HanamiWebpack::Config.manifest_file)
 
-      file = File.read(path)
+        file = File.read(path)
 
-      JSON.parse(file)
+        JSON.parse(file)
+      end
     end
 
     def self.manifest


### PR DESCRIPTION
Using the name `manifest.json` can conflict with the manifest file for mobile web browsers. This PR makes the name configurable and also caches the file read so that it does not happen on every lookup.