### PR TITLE
Uses first file in asset. Devmaps are included in Webpack 2.

### DIFF
--- a/lib/hanami_webpack/manifest.rb
+++ b/lib/hanami_webpack/manifest.rb
@@ -9,13 +9,13 @@ module HanamiWebpack
     def self.bundle_uri(bundle_name)
       raise HanamiWebpack::WebpackError, manifest['errors'] unless Hanami::Utils::Blank.blank?(manifest['errors'])
 
-      path = manifest['assetsByChunkName'][bundle_name]
+      path = Array(manifest['assetsByChunkName'][bundle_name])
 
-      if Hanami::Utils::Blank.blank?(path)
+      if path.empty?
         raise HanamiWebpack::EntryPointMissingError, "Can't find entry point '#{bundle_name}' in webpack manifest"
       end
 
-      path = Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(path).to_s
+      path = Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(path[0]).to_s
 
       if HanamiWebpack::Config.using_dev_server?
         path = "//#{HanamiWebpack::Config.dev_server_host}:#{HanamiWebpack::Config.dev_server_port}#{path}"


### PR DESCRIPTION
If using an external map file in Webpack 2, the assetsByChunkName is an array with the original and sourcemap. Or perhaps the plugin is now doing this, not sure. At any rate to get it to work I had to make some code changes.