### PR TITLE
Ensure encoding is set on gemspec

### DIFF
--- a/hanami-webpack.gemspec
+++ b/hanami-webpack.gemspec
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 Gem::Specification.new do |s|
   s.name        = 'hanami-webpack'
   s.version     = '0.0.1'


### PR DESCRIPTION
Set encoding on gemspec to avoid `invalid byte sequence in US-ASCII (ArgumentError)` from bundler