### PR TITLE
Switch to ManifestPlugin for manifest generation

### DIFF
--- a/lib/hanami_webpack/config.rb
+++ b/lib/hanami_webpack/config.rb
@@ -2,32 +2,33 @@ require 'hanami/utils/blank'
 
 module HanamiWebpack
   class Config
+    class << self
+      def public_path
+        ENV['WEBPACK_PUBLIC_PATH']
+      end
 
-    def self.public_path
-      ENV['WEBPACK_PUBLIC_PATH']
-    end
+      def manifest_file
+        ENV['WEBPACK_MANIFEST_FILE']
+      end
 
-    def self.manifest_file
-      ENV['WEBPACK_MANIFEST_FILE']
-    end
+      def dev_server_host
+        ENV['WEBPACK_DEV_SERVER_HOST']
+      end
 
-    def self.dev_server_host
-      ENV['WEBPACK_DEV_SERVER_HOST']
-    end
+      def dev_server_port
+        ENV['WEBPACK_DEV_SERVER_PORT']
+      end
 
-    def self.dev_server_port
-      ENV['WEBPACK_DEV_SERVER_PORT']
-    end
+      def inbuilt_dev_server?
+        ENV['INBUILT_WEBPACK_DEV_SERVER'] == 'true'
+      end
 
-    def self.inbuilt_dev_server?
-      ENV['INBUILT_WEBPACK_DEV_SERVER'] == 'true'
-    end
-
-    def self.using_dev_server?
-      if Hanami::Utils::Blank.blank?(ENV['WEBPACK_DEV_SERVER'])
-        ENV['RACK_ENV'] != 'production'
-      else
-        ENV['WEBPACK_DEV_SERVER'] == 'true'
+      def using_dev_server?
+        if Hanami::Utils::Blank.blank?(ENV['WEBPACK_DEV_SERVER'])
+          ENV['RACK_ENV'] != 'production'
+        else
+          ENV['WEBPACK_DEV_SERVER'] == 'true'
+        end
       end
     end
   end

--- a/lib/hanami_webpack/manifest.rb
+++ b/lib/hanami_webpack/manifest.rb
@@ -10,13 +10,13 @@ module HanamiWebpack
 
       raise HanamiWebpack::WebpackError, manifest['errors'] unless Hanami::Utils::Blank.blank?(manifest['errors'])
 
-      path = manifest['assetsByChunkName'][bundle_name]
+      path = manifest[bundle_name] || manifest['assetsByChunkName'][bundle_name]
 
       if Hanami::Utils::Blank.blank?(path)
         raise HanamiWebpack::EntryPointMissingError, "Can't find entry point '#{bundle_name}' in webpack manifest"
       end
 
-      path = Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(path).to_s
+      path = public_path(path)
 
       if HanamiWebpack::Config.using_dev_server?
         path = "//#{HanamiWebpack::Config.dev_server_host}:#{HanamiWebpack::Config.dev_server_port}#{path}"
@@ -26,7 +26,11 @@ module HanamiWebpack
     end
 
     def self.manifest_path
-      Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(HanamiWebpack::Config.manifest_file)
+      public_path(HanamiWebpack::Config.manifest_file)
+    end
+
+    def self.public_path(relative_path)
+      Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(relative_path)
     end
 
     def self.remote_manifest

--- a/lib/hanami_webpack/manifest.rb
+++ b/lib/hanami_webpack/manifest.rb
@@ -6,58 +6,62 @@ require_relative 'entry_point_missing_error'
 
 module HanamiWebpack
   class Manifest
-    def self.bundle_uri(bundle_name)
+    class << self
+      def bundle_uri(bundle_name)
 
-      raise HanamiWebpack::WebpackError, manifest['errors'] unless Hanami::Utils::Blank.blank?(manifest['errors'])
+        raise HanamiWebpack::WebpackError, manifest['errors'] unless Hanami::Utils::Blank.blank?(manifest['errors'])
 
-      path = manifest[bundle_name] || manifest['assetsByChunkName'][bundle_name]
+        path = manifest[bundle_name] || manifest['assetsByChunkName'][bundle_name]
 
-      if Hanami::Utils::Blank.blank?(path)
-        raise HanamiWebpack::EntryPointMissingError, "Can't find entry point '#{bundle_name}' in webpack manifest"
+        if Hanami::Utils::Blank.blank?(path)
+          raise HanamiWebpack::EntryPointMissingError, "Can't find entry point '#{bundle_name}' in webpack manifest"
+        end
+
+        path = public_path(path)
+
+        if HanamiWebpack::Config.using_dev_server?
+          path = "//#{HanamiWebpack::Config.dev_server_host}:#{HanamiWebpack::Config.dev_server_port}#{path}"
+        end
+
+        path
       end
 
-      path = public_path(path)
+      private
 
-      if HanamiWebpack::Config.using_dev_server?
-        path = "//#{HanamiWebpack::Config.dev_server_host}:#{HanamiWebpack::Config.dev_server_port}#{path}"
+      def manifest_path
+        public_path(HanamiWebpack::Config.manifest_file)
       end
 
-      path
-    end
-
-    def self.manifest_path
-      public_path(HanamiWebpack::Config.manifest_file)
-    end
-
-    def self.public_path(relative_path)
-      Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(relative_path)
-    end
-
-    def self.remote_manifest
-      host = HanamiWebpack::Config.dev_server_host
-      port = HanamiWebpack::Config.dev_server_port
-      http = Net::HTTP.new(host, port)
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      response = http.get(manifest_path).body
-      JSON.parse(response)
-    end
-
-    def self.static_manifest
-      @_manifest ||= begin
-        path =
-          Hanami
-            .public_directory
-            .join(*HanamiWebpack::Config.public_path.split('/'))
-            .join(HanamiWebpack::Config.manifest_file)
-
-        file = File.read(path)
-
-        JSON.parse(file)
+      def public_path(relative_path)
+        Hanami::Utils::PathPrefix.new('/').join(HanamiWebpack::Config.public_path).join(relative_path)
       end
-    end
 
-    def self.manifest
-      HanamiWebpack::Config.using_dev_server? ? remote_manifest : static_manifest
+      def remote_manifest
+        host = HanamiWebpack::Config.dev_server_host
+        port = HanamiWebpack::Config.dev_server_port
+        http = Net::HTTP.new(host, port)
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        response = http.get(manifest_path).body
+        JSON.parse(response)
+      end
+
+      def static_manifest
+        @_manifest ||= begin
+          path =
+            Hanami
+              .public_directory
+              .join(*HanamiWebpack::Config.public_path.split('/'))
+              .join(HanamiWebpack::Config.manifest_file)
+
+          file = File.read(path)
+
+          JSON.parse(file)
+        end
+      end
+
+      def manifest
+        HanamiWebpack::Config.using_dev_server? ? remote_manifest : static_manifest
+      end
     end
   end
 end

--- a/package.sample.json
+++ b/package.sample.json
@@ -2,8 +2,8 @@
   "name": "myApp",
   "version": "0.0.1",
   "devDependencies": {
-    "stats-webpack-plugin": "*",
     "webpack": "*",
-    "webpack-dev-server": "*"
+    "webpack-dev-server": "*",
+    "webpack-manifest-plugin": "*"
   }
 }

--- a/webpack.config.sample.js
+++ b/webpack.config.sample.js
@@ -1,5 +1,5 @@
 var path = require("path"),
-    StatsPlugin = require("stats-webpack-plugin");
+    ManifestPlugin = require("webpack-manifest-plugin");
 
 var devServerPort = process.env.WEBPACK_DEV_SERVER_PORT,
     devServerHost = process.env.WEBPACK_DEV_SERVER_HOST,
@@ -9,7 +9,7 @@ var config = {
   entry: {},
 
   output: {
-    path: path.join(__dirname, "public"),
+    path: path.join(__dirname, "public" + publicPath),
     filename: "[name]-[chunkhash].js"
   },
 
@@ -18,7 +18,9 @@ var config = {
   },
 
   plugins: [
-    new StatsPlugin("webpack_manifest.json")
+    new ManifestPlugin({
+      fileName: 'webpack_manifest.json'
+    })
   ]
 };
 
@@ -27,7 +29,6 @@ if (process.env.INBUILT_WEBPACK_DEV_SERVER) {
     port: devServerPort,
     headers: { "Access-Control-Allow-Origin": "*" }
   };
-  config.output.publicPath = "//" + devServerHost + ":" + devServerPort + "/";
 }
 
 module.exports = config;


### PR DESCRIPTION
I am using this gem on a side project. I have not yet hit production but I ran into some issues setting up integrated tests. Using StatsPlugin to generate the manifest was making it quite hard to figure out what was going wrong and it was also generating a manifest with far too much unneeded information. Switching to using the [ManifestPlugin](https://www.npmjs.com/package/webpack-manifest-plugin) plugin resolved it. Also, using the manifest plugin for this purpose is what the [official webpack documentation suggests](https://webpack.js.org/guides/output-management/#the-manifest).

This PR switches the gem to suggest using the manifest plugin by default. 
However, I've modified the code in such a way that it will still work if anyone is using StatsPlugin in the webpack config and updates, i.e. it's backwards compatible.

There is also some light refactoring but it's separated into its own commit so it will be easier to review it commit by commit. 