### PR TITLE
extended CSP handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -68,5 +68,11 @@ To build your assets when you deploy, you will need place on your `package.json`
 * Release on RubyGems.
 * Research a better way to do these things without monkey patches (I have done, but looks like that with the current Hanami version it's impossible).
 
+# Development
+
+* Clone the repo
+* Run `bundle install` to install everything needed
+* Run `rake` to run the tests
+
 ----------
 Samuel Simões ~ [@samuelsimoes](https://twitter.com/samuelsimoes) ~ [Blog](http://blog.samuelsimoes.com/)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs << "lib"
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
+end
+
+task default: :test

--- a/hanami-webpack.gemspec
+++ b/hanami-webpack.gemspec
@@ -9,4 +9,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'hanami'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'pry'
+  s.add_development_dependency 'test-unit'
 end

--- a/test/content_security_policy_test.rb
+++ b/test/content_security_policy_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class ContentSecurityPolicyTest < Test::Unit::TestCase
+  def security
+    @security ||= Hanami::Config::Security.new.tap do |s|
+      s.content_security_policy %{
+        form-action 'self';
+        frame-ancestors 'self';
+        base-uri 'self';
+        default-src 'none';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com/gtag/js?id=UA-XXX-Y;
+        connect-src 'self';
+        img-src 'self' https: data:;
+        style-src 'self' 'unsafe-inline' https:;
+        font-src 'self' https:;
+        object-src 'none';
+        plugin-types application/pdf;
+        child-src 'self';
+        frame-src 'self';
+        media-src 'self'
+      }
+    end
+  end
+
+  def test_hijack
+    expected = %{
+      form-action 'self';
+      frame-ancestors 'self';
+      base-uri 'self';
+      default-src 'none';
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com/gtag/js?id=UA-XXX-Y http://test.host:54321;
+      connect-src 'self' http://test.host:54321 ws://test.host:54321;
+      img-src 'self' https: data:;
+      style-src 'self' 'unsafe-inline' https: http://test.host:54321;
+      font-src 'self' https: http://test.host:54321;
+      object-src 'none';
+      plugin-types application/pdf;
+      child-src 'self';
+      frame-src 'self';
+      media-src 'self'
+    }.split(Hanami::Config::Security::SEPARATOR).map(&:strip).join(Hanami::Config::Security::SPACED_SEPARATOR)
+    assert_equal security.content_security_policy, expected
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+ENV['WEBPACK_DEV_SERVER']      = 'true'
+ENV['WEBPACK_DEV_SERVER_HOST'] = 'test.host'
+ENV['WEBPACK_DEV_SERVER_PORT'] = '54321'
+
+require "test/unit"
+require "pry"
+require "hanami-webpack"


### PR DESCRIPTION
currently, only the `script-src` directive gets the webpack dev server url appended and that under the assumption that i'd like my `script-src` replaced the following way:

replace `script-src 'self'` with `script-src 'self' 'unsafe-eval' http://webpack`.

which only really works if i have a policy of excactly `script-src 'self' ...`.
also, it does not append all the other necessary policies, that is:
- `connect-src` for the hot-reload feature of webpack
- `font-src` for webpack-packaged fonts
- `style-src` for webpack-packaged stylesheets
- `script-src` for webpack-packaged javascripts

this patch fixes this.

also introduces proper testing (at least for this feature).